### PR TITLE
Fix "blank" gender to not print the word "blank" on the character sheet

### DIFF
--- a/index.php
+++ b/index.php
@@ -92,7 +92,7 @@
 				<option value="Male" selected>Male</option>
 				<option value="Female">Female</option>
 				<option value="Other">Other</option>
-				<option value="Blank">Blank</option>
+				<option value="">Blank</option>
         </select>
         
         <br/>


### PR DESCRIPTION
Currently selecting "Blank" for gender in the MCC character generator will explicitly print the word "Blank" under gender on the resulting character sheet. This corrects that by changing the value to null for the Blank gender option.